### PR TITLE
Handle reaction_added messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/slackhq/hubot-slack/issues"
   },
   "dependencies": {
-    "slack-client": "~1.4.0"
+    "slack-client": "18f/node-slack-client#1.5.0-handle-reaction-added"
   },
   "devDependencies": {
     "coffee-script": "~1.7.1",

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -38,6 +38,7 @@ class SlackBot extends Adapter
     @client.on 'open', @.open
     @client.on 'close', @.clientClose
     @client.on 'message', @.message
+    @client.on 'reaction_added', @.reactionAdded
     @client.on 'userChange', @.userChange
     @robot.brain.on 'loaded', @.brainLoaded
 
@@ -107,6 +108,7 @@ class SlackBot extends Adapter
       @client.removeListener 'open', @.open
       @client.removeListener 'close', @.clientClose
       @client.removeListener 'message', @.message
+      @client.removeListener 'reaction_added', @.reactionAdded
       @client.removeListener 'userChange', @.userChange
       process.exit 1
     else
@@ -170,6 +172,12 @@ class SlackBot extends Adapter
         text = "#{@robot.name} #{text}"
 
       @receive new SlackTextMessage user, text, rawText, msg
+
+  reactionAdded: (msg) =>
+    user = @robot.brain.userForId msg.user
+    rawText = msg.item.message.text
+    text = @removeFormatting rawText
+    @receive new SlackTextMessage user, text, rawText, msg
 
   removeFormatting: (text) ->
     # https://api.slack.com/docs/formatting

--- a/test/message.coffee
+++ b/test/message.coffee
@@ -133,6 +133,35 @@ describe 'Receiving a Slack message', ->
     msg = @stubs.robot.received[0]
     msg.should.be.an.instanceOf SlackRawMessage
 
+  it 'should produce a SlackTextMessage for reaction_added events', ->
+    userId = @stubs.user.id
+    channelId = @stubs.channel.id
+    @slackbot.reactionAdded new ClientMessage {
+      type: 'reaction_added'
+      user: userId
+      name: 'evergreen_tree'
+      item: {
+        type: 'message'
+        channel: channelId
+        message: {
+          text: 'Hello, world!'
+          reactions: [
+            {
+              name: 'evergreen_tree'
+              count: 1
+              users: [ userId ]
+            }
+          ]
+        }
+      }
+      event_ts: '1234'
+    }
+    @stubs.robot.received.should.have.length 1
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf SlackTextMessage
+    msg.user.id.should.equal userId
+    msg.rawMessage.name.should.equal 'evergreen_tree'
+
   describe 'should handle SlackRawMessage inheritance properly when Hubot', ->
     # this is a bit of a wacky one
     # We need to muck with the require() machinery


### PR DESCRIPTION
Converts them to SlackTextMessages before passing them to Hubot.

Next stop: getting [18F/18f-bot](https://github.com/18F/18f-bot/) to depend on this version for the near-term.

cc: @ccostino @jeremiak @afeld
