### PR TITLE
handle reaction_removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/slackhq/hubot-slack/issues"
   },
   "dependencies": {
-    "slack-client": "18f/node-slack-client#1.5.0-handle-reaction-added"
+    "slack-client": "skehlet/node-slack-client#handle-reaction-removed"
   },
   "devDependencies": {
     "coffee-script": "~1.7.1",

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -38,7 +38,8 @@ class SlackBot extends Adapter
     @client.on 'open', @.open
     @client.on 'close', @.clientClose
     @client.on 'message', @.message
-    @client.on 'reaction_added', @.reactionAdded
+    @client.on 'reaction_added', @.reaction
+    @client.on 'reaction_removed', @.reaction
     @client.on 'userChange', @.userChange
     @robot.brain.on 'loaded', @.brainLoaded
 

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -108,7 +108,8 @@ class SlackBot extends Adapter
       @client.removeListener 'open', @.open
       @client.removeListener 'close', @.clientClose
       @client.removeListener 'message', @.message
-      @client.removeListener 'reaction_added', @.reactionAdded
+      @client.removeListener 'reaction_added', @.reaction
+      @client.removeListener 'reaction_removed', @.reaction
       @client.removeListener 'userChange', @.userChange
       process.exit 1
     else
@@ -173,7 +174,7 @@ class SlackBot extends Adapter
 
       @receive new SlackTextMessage user, text, rawText, msg
 
-  reactionAdded: (msg) =>
+  reaction: (msg) =>
     # Ignore our own reactions
     return if msg.user == @self.id
 


### PR DESCRIPTION
Hello, this PR adds support for `reaction_removed`. Requires [this other PR](https://github.com/18F/node-slack-client/pull/2).
Sorry I'm still kind of a git noob, just getting this far was an accomplishment. I'm guessing you don't want to merge in changes that point to my branch. I can fix up `package.json` if that other PR gets merged. Thanks!
